### PR TITLE
Added option to disable file extension check

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,23 @@ grunt.initConfig({
 });
 ```
 
+#### Ignore file extension
+
+By default, only files with the `.properties` file extension are processed. This is helpful if there are different file types in a directory and only the property files should be processed. You can set the option `ignoreFileExtension` to enable processing property files with another extension.
+
+```js
+grunt.initConfig({
+    propertiesToJSON: {
+        main: {
+            src: ['path/to/properties/properties.with.other.extension'],
+            options: {
+                ignoreFileExtension: true
+            }
+        }
+    }
+});
+```
+
 ## License
 
 This project is released under the MIT license.

--- a/tasks/properties-to-json.js
+++ b/tasks/properties-to-json.js
@@ -93,7 +93,7 @@ module.exports = function(grunt) {
                     dataList.push(data);
                 } else {
                     dest = f.dest ? path.join(f.dest, path.basename(src)) : src;
-                    if (options.ignoreFileExtension) {
+                    if (src.substr(-11) !== '.properties') {
                         dest += '.json';
                     } else {
                         dest = dest.replace('.properties','.json');

--- a/tasks/properties-to-json.js
+++ b/tasks/properties-to-json.js
@@ -73,7 +73,7 @@ module.exports = function(grunt) {
             dataList = [];
 
             f.src.forEach(function(src) {
-                if (src.substr(-11) !== '.properties') {
+                if (!options.ignoreFileExtension && src.substr(-11) !== '.properties') {
                     return;
                 }
                 if (!grunt.file.exists(src)) {

--- a/tasks/properties-to-json.js
+++ b/tasks/properties-to-json.js
@@ -93,7 +93,11 @@ module.exports = function(grunt) {
                     dataList.push(data);
                 } else {
                     dest = f.dest ? path.join(f.dest, path.basename(src)) : src;
-                    dest = dest.replace('.properties','.json');
+                    if (options.ignoreFileExtension) {
+                        dest += '.json';
+                    } else {
+                        dest = dest.replace('.properties','.json');
+                    }
                     writeFile(data, dest);
                 }
             });


### PR DESCRIPTION
Thanks for your great plugin. I have added an option to ignore the file extension check. This makes it possible to process also property files with another extension.

Hope, you appreciate this improvement.